### PR TITLE
Allow to pass module info when loader has an error.

### DIFF
--- a/lib/LoaderRunner.js
+++ b/lib/LoaderRunner.js
@@ -171,7 +171,7 @@ function processResource(options, loaderContext, callback) {
 			if(err) return callback(err);
 			options.resourceBuffer = buffer;
 			iterateNormalLoaders(options, loaderContext, [buffer], callback);
-		})
+		});
 	} else {
 		iterateNormalLoaders(options, loaderContext, [null], callback);
 	}
@@ -259,7 +259,7 @@ exports.runLoaders = function runLoaders(options, callback) {
 		get: function() {
 			if(loaderContext.resourcePath === undefined)
 				return undefined;
-			return loaderContext.resourcePath + loaderContext.resourceQuery
+			return loaderContext.resourcePath + loaderContext.resourceQuery;
 		},
 		set: function(value) {
 			var splittedResource = value && splitQuery(value);
@@ -324,8 +324,7 @@ exports.runLoaders = function runLoaders(options, callback) {
 		readResource: readResource
 	};
 	iteratePitchingLoaders(processOptions, loaderContext, function(err, result) {
-		if(err) return callback(err);
-		callback(null, {
+		callback(err, {
 			result: result,
 			resourceBuffer: processOptions.resourceBuffer,
 			cacheable: requestCacheable,

--- a/test/fixtures/simple-async-error-loader.js
+++ b/test/fixtures/simple-async-error-loader.js
@@ -1,0 +1,6 @@
+module.exports = function(source) {
+	var callback = this.async();
+	setTimeout(function() {
+		callback(new Error(), null);
+	}, 50);
+};

--- a/test/runLoaders.js
+++ b/test/runLoaders.js
@@ -54,6 +54,23 @@ describe("runLoaders", function() {
 			done();
 		});
 	});
+	it("should process a simple async loader when error allow to pass module info", function(done) {
+		runLoaders({
+			resource: path.resolve(fixtures, "resource.bin"),
+			loaders: [
+				path.resolve(fixtures, "simple-async-error-loader.js")
+			]
+		}, function(err, result) {
+			if(err) {
+				result.cacheable.should.be.eql(true);
+				result.fileDependencies.should.be.eql([
+					path.resolve(fixtures, "resource.bin")
+				]);
+				result.contextDependencies.should.be.eql([]);
+			}
+			done();
+		});
+	});
 	it("should process multiple simple loaders", function(done) {
 		runLoaders({
 			resource: path.resolve(fixtures, "resource.bin"),


### PR DESCRIPTION
Minor change, this is needed for watch mode.

ref: https://github.com/webpack/webpack/issues/1975