### PR TITLE
add context.exec

### DIFF
--- a/lib/LoaderRunner.js
+++ b/lib/LoaderRunner.js
@@ -254,6 +254,18 @@ exports.runLoaders = function runLoaders(options, callback) {
 		contextDependencies.length = 0;
 		requestCacheable = true;
 	};
+	loaderContext.exec = function exec(code, filename) {
+		if(typeof __webpack_modules__ === "undefined") {
+			var Module = require("module");
+			var m = new Module(filename, module);
+			m.paths = Module._nodeModulePaths(loaderContext.context);
+			m.filename = filename;
+			m._compile(code, filename);
+			return m.exports;
+		} else {
+			throw new Error("loaderContext.exec is not supported");
+		}
+	};
 	Object.defineProperty(loaderContext, "resource", {
 		enumerable: true,
 		get: function() {

--- a/test/fixtures/exec-loader.js
+++ b/test/fixtures/exec-loader.js
@@ -1,0 +1,3 @@
+module.exports = function(source) {
+	return JSON.stringify(this.exec(source, this.resource)());
+};

--- a/test/fixtures/simple-resource.js
+++ b/test/fixtures/simple-resource.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+	return "exec";
+};

--- a/test/runLoaders.js
+++ b/test/runLoaders.js
@@ -174,6 +174,18 @@ describe("runLoaders", function() {
 			done();
 		});
 	});
+	it("should process loaders depend on context.exec", function(done) {
+		runLoaders({
+			resource: path.resolve(fixtures, "simple-resource.js"),
+			loaders: [
+				path.resolve(fixtures, "exec-loader.js")
+			]
+		}, function(err, result) {
+			if(err) return done(err);
+			result.result[0].should.be.eql("\"exec\"");
+			done();
+		});
+	});
 	it("should process omit BOM on string convertion", function(done) {
 		runLoaders({
 			resource: path.resolve(fixtures, "bom.bin"),


### PR DESCRIPTION
Support `context.exec` feature.

In some loaders, `this.exec` is used. So add this feature will prevent some loader fail to run.

fix #2 
