### PR TITLE
Fix the callback function being called twice

### DIFF
--- a/lib/loadLoader.js
+++ b/lib/loadLoader.js
@@ -1,13 +1,13 @@
 module.exports = function loadLoader(loader, callback) {
 	if(typeof System === "object" && typeof System.import === "function") {
-		System.import(loader.path).catch(callback).then(function(module) {
+		System.import(loader.path).then(function(module) {
 			loader.normal = module.default;
 			loader.pitch = module.pitch;
 			loader.raw = module.raw;
 			if(typeof loader.normal !== "function" && typeof loader.pitch !== "function")
 				throw new Error("Module '" + loader.path + "' is not a loader (must have normal or pitch function)");
 			callback();
-		});
+		}, callback);
 	} else {
 		try {
 			var module = require(loader.path);


### PR DESCRIPTION
Why the System.import handler is being executed after `.catch(callback)` Is this by design? `module` is `undefined` at that stage and leads to unhandled exception.
