### PR TITLE
fix logic for loading the normal loader via System.import

### DIFF
--- a/lib/loadLoader.js
+++ b/lib/loadLoader.js
@@ -1,7 +1,7 @@
 module.exports = function loadLoader(loader, callback) {
 	if(typeof System === "object" && typeof System.import === "function") {
 		System.import(loader.path).catch(callback).then(function(module) {
-			loader.normal = module.default;
+			loader.normal = typeof module === "function" ? module : module.default;
 			loader.pitch = module.pitch;
 			loader.raw = module.raw;
 			if(typeof loader.normal !== "function" && typeof loader.pitch !== "function")

--- a/test/runLoaders.js
+++ b/test/runLoaders.js
@@ -383,6 +383,29 @@ describe("runLoaders", function() {
 			done();
 		});
 	});
+	it("should load a loader using System.import and process", function(done) {
+		global.System = {
+			import: function(moduleId) {
+				return Promise.resolve(require(moduleId));
+			}
+		};
+		runLoaders({
+			resource: path.resolve(fixtures, "resource.bin"),
+			loaders: [
+				path.resolve(fixtures, "simple-loader.js")
+			]
+		}, function(err, result) {
+			if(err) return done(err);
+			result.result.should.be.eql(["resource-simple"]);
+			result.cacheable.should.be.eql(true);
+			result.fileDependencies.should.be.eql([
+				path.resolve(fixtures, "resource.bin")
+			]);
+			result.contextDependencies.should.be.eql([]);
+			done();
+		});
+		delete global.System;
+	});
 	describe("getContext", function() {
 		var TESTS = [
 			["/", "/"],


### PR DESCRIPTION
fixes https://github.com/webpack/webpack/issues/3180

Why is the async System.import tried BEFORE a NodeJS require, anyway?