### PR TITLE
Fix Promise issues where callback was being called twice

### DIFF
--- a/lib/LoaderRunner.js
+++ b/lib/LoaderRunner.js
@@ -123,9 +123,9 @@ function runSyncOrAsync(fn, context, args, callback) {
 			if(result === undefined)
 				return callback();
 			if(result && typeof result === "object" && typeof result.then === "function") {
-				return result.catch(callback).then(function(r) {
+				return result.then(function(r) {
 					callback(null, r);
-				});
+				}, callback);
 			}
 			return callback(null, result);
 		}

--- a/lib/loadLoader.js
+++ b/lib/loadLoader.js
@@ -1,13 +1,13 @@
 module.exports = function loadLoader(loader, callback) {
 	if(typeof System === "object" && typeof System.import === "function") {
-		System.import(loader.path).catch(callback).then(function(module) {
+		System.import(loader.path).then(function(module) {
 			loader.normal = typeof module === "function" ? module : module.default;
 			loader.pitch = module.pitch;
 			loader.raw = module.raw;
 			if(typeof loader.normal !== "function" && typeof loader.pitch !== "function")
 				throw new Error("Module '" + loader.path + "' is not a loader (must have normal or pitch function)");
 			callback();
-		});
+		}, callback);
 	} else {
 		try {
 			var module = require(loader.path);


### PR DESCRIPTION
This supersedes PR #5 by cherry-picking the commit by @koistya (resolving merge conflict) and then adding another commit where another `.catch(callback).then(...)` was causing a callback to be called twice, thus making Webpack throw an exception from inside the `async` module.