### PR TITLE
the type of module export should be checked, not the loader metadata

### DIFF
--- a/lib/loadLoader.js
+++ b/lib/loadLoader.js
@@ -26,7 +26,7 @@ module.exports = function loadLoader(loader, callback) {
 			}
 			return callback(e);
 		}
-		if(typeof loader !== "function" && typeof loader !== "object")
+		if(typeof module !== "function" && typeof module !== "object")
 			throw new Error("Module '" + loader.path + "' is not a loader (export function or es6 module))");
 		loader.normal = typeof module === "function" ? module : module.default;
 		loader.pitch = module.pitch;


### PR DESCRIPTION
I was just reading some source code and this looked wrong. if not, feel free to delete this PR.