### PR TITLE
fix small typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ runLoaders({
 	// The raw resource as Buffer (useful for SourceMaps)
 
 	// result.cacheable: Bool
-	// Is the result cacheable or do it require reexecution?
+	// Is the result cacheable or does it require reexecution?
 
 	// result.fileDependencies: String[]
 	// An array of paths (files) on which the result depends on


### PR DESCRIPTION
Hey! I was reading the docs about how to write loaders for webpack and I made my way to the laoder-runner repo where I believe I found a minor typo in the readme. Let me know what you think! Thanks!
