### PR TITLE
Increase parity between "pitch" & "normal" loaders

### DIFF
--- a/lib/LoaderRunner.js
+++ b/lib/LoaderRunner.js
@@ -178,7 +178,7 @@ function iteratePitchingLoaders(options, loaderContext, callback) {
 			function(err) {
 				if(err) return callback(err);
 				var args = Array.prototype.slice.call(arguments, 1);
-				if(args.length > 0) {
+				if(args[0] !== undefined) {
 					loaderContext.loaderIndex--;
 					iterateNormalLoaders(options, loaderContext, args, callback);
 				} else {

--- a/lib/LoaderRunner.js
+++ b/lib/LoaderRunner.js
@@ -178,7 +178,13 @@ function iteratePitchingLoaders(options, loaderContext, callback) {
 			function(err) {
 				if(err) return callback(err);
 				var args = Array.prototype.slice.call(arguments, 1);
-				if(args[0] !== undefined) {
+				// Determine whether to continue the pitching process based on
+				// argument values (as opposed to argument presence) in order
+				// to support synchronous and asynchronous usages.
+				var hasArg = args.some(function(value) {
+					return value !== undefined;
+				});
+				if(hasArg) {
 					loaderContext.loaderIndex--;
 					iterateNormalLoaders(options, loaderContext, args, callback);
 				} else {

--- a/test/fixtures/pitch-async-undef-loader.js
+++ b/test/fixtures/pitch-async-undef-loader.js
@@ -1,0 +1,7 @@
+exports.pitch = function() {
+	var done = this.async();
+
+	setTimeout(function() {
+		done(null, undefined);
+	}, 0);
+};

--- a/test/fixtures/pitch-async-undef-some-loader.js
+++ b/test/fixtures/pitch-async-undef-some-loader.js
@@ -1,0 +1,7 @@
+exports.pitch = function() {
+	var done = this.async();
+
+	setTimeout(function() {
+		done(null, undefined, "not undefined");
+	}, 0);
+};

--- a/test/fixtures/pitch-promise-undef-loader.js
+++ b/test/fixtures/pitch-promise-undef-loader.js
@@ -1,0 +1,3 @@
+exports.pitch = function() {
+	return Promise.resolve();
+};

--- a/test/runLoaders.js
+++ b/test/runLoaders.js
@@ -114,6 +114,27 @@ describe("runLoaders", function() {
 			done();
 		});
 	});
+	it("should interpret explicit `undefined` values from async 'pitch' loaders", function(done) {
+		runLoaders({
+			resource: path.resolve(fixtures, "resource.bin"),
+			loaders: [
+				path.resolve(fixtures, "simple-loader.js"),
+				path.resolve(fixtures, "pitch-async-undef-loader.js"),
+				path.resolve(fixtures, "pitch-promise-undef-loader.js")
+			]
+		}, function(err, result) {
+			if(err) return done(err);
+			result.result.should.be.eql([
+				"resource-simple"
+			]);
+			result.cacheable.should.be.eql(true);
+			result.fileDependencies.should.be.eql([
+				path.resolve(fixtures, "resource.bin")
+			]);
+			result.contextDependencies.should.be.eql([]);
+			done();
+		});
+	});
 	it("should be possible to add dependencies", function(done) {
 		runLoaders({
 			resource: path.resolve(fixtures, "resource.bin"),

--- a/test/runLoaders.js
+++ b/test/runLoaders.js
@@ -153,7 +153,6 @@ describe("runLoaders", function() {
 			done();
 		});
 	});
-
 	it("should be possible to add dependencies", function(done) {
 		runLoaders({
 			resource: path.resolve(fixtures, "resource.bin"),

--- a/test/runLoaders.js
+++ b/test/runLoaders.js
@@ -135,6 +135,25 @@ describe("runLoaders", function() {
 			done();
 		});
 	});
+	it("should interrupt pitching when async loader completes with any additional non-undefined values", function(done) {
+		runLoaders({
+			resource: path.resolve(fixtures, "resource.bin"),
+			loaders: [
+				path.resolve(fixtures, "simple-loader.js"),
+				path.resolve(fixtures, "pitch-async-undef-some-loader.js")
+			]
+		}, function(err, result) {
+			if(err) return done(err);
+			result.result.should.be.eql([
+				"undefined-simple"
+			]);
+			result.cacheable.should.be.eql(true);
+			result.fileDependencies.should.be.eql([]);
+			result.contextDependencies.should.be.eql([]);
+			done();
+		});
+	});
+
 	it("should be possible to add dependencies", function(done) {
 		runLoaders({
 			resource: path.resolve(fixtures, "resource.bin"),


### PR DESCRIPTION
Webpack's documentation describes the default behavior of "pitching"
loaders as follows [1]:

> [...] If a loader delivers a result in the pitch method the process
> turns around and skips the remaining loaders, continuing with the
> calls to the more left loaders. [...]

This implicitly suggests that the "pitching" behavior will not take
place when a value is not returned. The loader will be "skipped", and
traversal through the chain of loaders will continue.

In synchronous "pitching" loaders, the skipping behavior can be
triggered by explicitly returning the `undefined` value or by omitting a
return statement altogether.

In asynchronous "pitching" loaders which signal completion via a
callback function, the skipping behavior can only be triggered by
invoking the callback function with zero or 1 arguments. If a second
argument value is specified as `undefined`, that value is interpreted as
invalid source code (rather than a signal to continue traversing the
chain of loaders). This argument-length-driven behavior is inconvenient
because it requires consumers maintain a dedicated code path for the
described condition (which may explain why such APIs are relatively rare
in idiomatic Node.js code).

In asynchronous "pitching" loaders which signal completion via a Promise
value, this same implementation detail makes it impossible to trigger
the skipping behavior.

Consistently interpret the value `undefined` as a signal to skip the
loader, whether specified as return value from synchronous loaders, an
asynchronous callback value, or an asynchronous Promise resolution
value.

[1] https://webpack.js.org/api/loaders/#pitching-loader

This is intended to resolve https://github.com/webpack/webpack/issues/5782