### PR TITLE
Avoid using deprecated Buffer constructor

### DIFF
--- a/lib/LoaderRunner.js
+++ b/lib/LoaderRunner.js
@@ -149,7 +149,7 @@ function convertArgs(args, raw) {
 	if(!raw && Buffer.isBuffer(args[0]))
 		args[0] = utf8BufferToString(args[0]);
 	else if(raw && typeof args[0] === "string")
-		args[0] = new Buffer(args[0], "utf-8"); // eslint-disable-line
+		args[0] = Buffer.from(args[0], "utf-8");
 }
 
 function iteratePitchingLoaders(options, loaderContext, callback) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/webpack/loader-runner#readme",
   "engines": {
-    "node": ">=4.5.0 <5.0.0 || >=5.10"
+    "node": ">=6.11.5"
   },
   "files": [
     "lib/",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/webpack/loader-runner#readme",
   "engines": {
-    "node": ">=4.3.0 <5.0.0 || >=5.10"
+    "node": ">=4.5.0 <5.0.0 || >=5.10"
   },
   "files": [
     "lib/",

--- a/test/fixtures/raw-loader.js
+++ b/test/fixtures/raw-loader.js
@@ -1,5 +1,5 @@
 exports.__es6Module = true;
 exports.default = function(source) {
-	return new Buffer(source.toString("hex") + source.toString("utf-8"), "utf-8"); // eslint-disable-line
+	return Buffer.from(source.toString("hex") + source.toString("utf-8"), "utf-8");
 };
 exports.raw = true;

--- a/test/runLoaders.js
+++ b/test/runLoaders.js
@@ -11,7 +11,7 @@ describe("runLoaders", function() {
 			resource: path.resolve(fixtures, "resource.bin")
 		}, function(err, result) {
 			if(err) return done(err);
-			result.result.should.be.eql([new Buffer("resource", "utf-8")]); // eslint-disable-line
+			result.result.should.be.eql([Buffer.from("resource", "utf-8")]);
 			result.cacheable.should.be.eql(true);
 			result.fileDependencies.should.be.eql([
 				path.resolve(fixtures, "resource.bin")


### PR DESCRIPTION
This raises the minimum Node.js version from 4.3.0 to 4.5.0, but that should be fine, as 4.5.0 was released very long ago and even the whole 4.x branch will be out of LTS support soon.

Probably almost no one uses Node.js versions 4.3.x and 4.4.x nowdays.

webpack/webpack states `"node": ">=6.11.5"` requirement already.

Also this removes those `// eslint-disable-line` comments. :wink:

Lint failure is unrelated and happens because of the function named `async`, upon fixing that — tests pass locally.

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor
https://github.com/webpack/webpack/pull/6356