### PR TITLE
travis: test on latest 6.x/8.x/10.x Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - "4.0"
-  - "5.0"
+  - "6"
+  - "8"
+  - "10"
   - node
 script: npm run travis
 


### PR DESCRIPTION
Previosly, the tests were done on 4.0.x and 5.0.x, both of which reached EOL.
Note that 4.0.x and 5.0.x are both unsupported by this package in `package.json`.