### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/LoaderRunner.js
+++ b/lib/LoaderRunner.js
@@ -9,7 +9,7 @@ var loadLoader = require("./loadLoader");
 function utf8BufferToString(buf) {
 	var str = buf.toString("utf-8");
 	if(str.charCodeAt(0) === 0xFEFF) {
-		return str.substr(1);
+		return str.slice(1);
 	} else {
 		return str;
 	}
@@ -39,8 +39,8 @@ function dirname(path) {
 	var idx = i > j ? i : j;
 	var idx2 = i > j ? i2 : j2;
 	if(idx < 0) return path;
-	if(idx === idx2) return path.substr(0, idx + 1);
-	return path.substr(0, idx);
+	if(idx === idx2) return path.slice(0, idx + 1);
+	return path.slice(0, idx);
 }
 
 function createLoaderObject(loader) {


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Breaking Changes

None

### Additional Info
