### PR TITLE
fix: always set `resource`, `resourcePath`, `resourceQuery` and `resourceFragment` to empty string when they are unavaliable

### DIFF
--- a/lib/LoaderRunner.js
+++ b/lib/LoaderRunner.js
@@ -316,11 +316,11 @@ module.exports.runLoaders = function runLoaders(options, callback) {
 
 	//
 	const splittedResource = resource && parsePathQueryFragment(resource);
-	const resourcePath = splittedResource ? splittedResource.path : undefined;
-	const resourceQuery = splittedResource ? splittedResource.query : undefined;
+	const resourcePath = splittedResource ? splittedResource.path : "";
+	const resourceQuery = splittedResource ? splittedResource.query : "";
 	const resourceFragment = splittedResource
 		? splittedResource.fragment
-		: undefined;
+		: "";
 	const contextDirectory = resourcePath ? dirname(resourcePath) : null;
 
 	// execution state

--- a/test/runLoaders.js
+++ b/test/runLoaders.js
@@ -370,6 +370,10 @@ describe("runLoaders", () => {
 				try {
 					JSON.parse(result.result[0]).should.be.eql({
 						context: null,
+						resource: "",
+						resourcePath: "",
+						resourceQuery: "",
+						resourceFragment: "",
 						loaderIndex: 1,
 						query: "",
 						currentRequest: `${path.resolve(fixtures, "keys-loader.js")}!`,


### PR DESCRIPTION


fixes https://github.com/webpack/webpack/pull/18157/