### PR TITLE
docs: clarify that result.result is an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ runLoaders(
 	},
 	(err, result) => {
 		// err: Error?
-		// result.result: Buffer | String
-		// The result
+		// result.result: [Buffer | String, SourceMap?, Meta?]
+		// The result as an array matching the arguments passed by the final normal loader
+		// (typically [content, sourceMap, meta])
 		// only available when no error occurred
 		// result.resourceBuffer: Buffer
 		// The raw resource as Buffer (useful for SourceMaps)


### PR DESCRIPTION
fixes #51

The README incorrectly documented `result.result` as `Buffer | String`, but it is actually an array of all arguments passed by the final normal loader (typically [content, sourceMap, meta]).

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->